### PR TITLE
Update config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,10 +7,11 @@ import (
 
 func Load(filePath string, configuration interface{}) error {
 	configFile, err := os.Open(filePath)
-	defer configFile.Close()
 	if err != nil {
 		return err
 	}
+	defer configFile.Close()
+	
 	jsonParser := json.NewDecoder(configFile)
 	jsonParser.Decode(&configuration)
 	return nil


### PR DESCRIPTION
You can't close the file that was not be opened because of an error.